### PR TITLE
added option to use GET for AJAX requests if 'code' parameter non empty. 

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -24,6 +24,17 @@ from tools import hilite_me, update_styles
 
 class ApiHandler(webapp.RequestHandler):
     def get(self):
+        if self.request.get('code') != '':
+        code = self.request.get('code')
+        lexer = self.request.get('lexer')
+        style = self.request.get('style')
+        linenos = self.request.get('linenos')
+        divstyles = update_styles(style, self.request.get('divstyles'))
+        html = hilite_me(code, lexer, style, linenos, divstyles)
+        self.response.headers["Content-Type"] = "text/plain"
+        self.response.out.write(html)
+
+        else:
         path = os.path.join(os.path.dirname(__file__), 'templates/api.txt')
         self.response.headers["Content-Type"] = "text/plain"
         self.response.out.write(template.render(path, {}))


### PR DESCRIPTION
added option to use GET for AJAX requests if 'code' parameter non empty. This change caused code redundance. Need a fix.
